### PR TITLE
Use our fork of ouster-sdk temporarily

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ouster-sdk"]
 	path = ouster-sdk
-	url = https://github.com/ouster-lidar/ouster_example.git
+	url = git@github.com:GITAI/ouster_example.git


### PR DESCRIPTION
This PR temporarily switches the `ouster-sdk` submodule from the official one to our fork to get around the build issue.

- https://github.com/ouster-lidar/ouster_example/pull/566