### PR TITLE
Pin ouster-sdk version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ouster-sdk"]
 	path = ouster-sdk
 	url = git@github.com:ouster-lidar/ouster_example.git
+	branch = 1f73d012c489d71ba6c88f56c6726369e83c8b57


### PR DESCRIPTION
- Original repository does not work due to the error fixed by this PR : https://github.com/ouster-lidar/ouster_example/pull/566
- I requested to release new version including the fix : https://github.com/ouster-lidar/ouster_example/issues/588
- However, they also included other breaking changes to the new release 👎 

We have to pin the SDK version to unreleased commit...